### PR TITLE
Add option to use the latest offset 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ pip install -r requirements.txt
 export KAFKA_CA_FILE=<cafile>
 export KAFKA_CERT_FILE=<certfile>
 export KAFKA_PRIVATE_KEY=<privatekey>
-python kafka-consumer.py <broker> <topic>
+python kafka-consumer.py <broker> <topic> <is_using_latest_offset>
 ```


### PR DESCRIPTION
# Why
- By default `OffsetType.EARLIEST` is used by pykafka when there is no initial offset

# What
- Add option to use the latest offset type instead of the earliest

# How to use
To use the latest offset instead of earliest, pass truthy value (e.g. `1` or `true`) to the last argument when running the script, e.g. `python kafka-consumer.py broker:port my_topic true`